### PR TITLE
add throttler to gql sample to illustrate bug reading 'header' of undefined

### DIFF
--- a/sample/23-graphql-code-first/package-lock.json
+++ b/sample/23-graphql-code-first/package-lock.json
@@ -15,6 +15,7 @@
         "@nestjs/core": "9.3.12",
         "@nestjs/graphql": "11.0.0",
         "@nestjs/platform-express": "9.3.12",
+        "@nestjs/throttler": "^4.0.0",
         "class-transformer": "0.5.1",
         "class-validator": "0.14.0",
         "graphql": "16.6.0",
@@ -2301,6 +2302,19 @@
         }
       }
     },
+    "node_modules/@nestjs/throttler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-4.0.0.tgz",
+      "integrity": "sha512-2T2S/hFhxROa/PZRZhHWFkrukxg3T8Db32Y04m6U6j6N2XqFGSKXhjfIbORO8kk/S2jswa9oTX/K12E120tgaQ==",
+      "dependencies": {
+        "md5": "^2.2.1"
+      },
+      "peerDependencies": {
+        "@nestjs/common": "^7.0.0 || ^8.0.0 || ^9.0.0",
+        "@nestjs/core": "^7.0.0 || ^8.0.0 || ^9.0.0",
+        "reflect-metadata": "^0.1.13"
+      }
+    },
     "node_modules/@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -3796,6 +3810,14 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "node_modules/charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA==",
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -4116,6 +4138,14 @@
       },
       "engines": {
         "node": ">= 8"
+      }
+    },
+    "node_modules/crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow==",
+      "engines": {
+        "node": "*"
       }
     },
     "node_modules/cssfilter": {
@@ -5952,6 +5982,11 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
     "node_modules/is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -7420,6 +7455,16 @@
       "dev": true,
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "dependencies": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "node_modules/media-typer": {
@@ -11668,6 +11713,14 @@
         "tslib": "2.5.0"
       }
     },
+    "@nestjs/throttler": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@nestjs/throttler/-/throttler-4.0.0.tgz",
+      "integrity": "sha512-2T2S/hFhxROa/PZRZhHWFkrukxg3T8Db32Y04m6U6j6N2XqFGSKXhjfIbORO8kk/S2jswa9oTX/K12E120tgaQ==",
+      "requires": {
+        "md5": "^2.2.1"
+      }
+    },
     "@nodelib/fs.scandir": {
       "version": "2.1.5",
       "resolved": "https://registry.npmjs.org/@nodelib/fs.scandir/-/fs.scandir-2.1.5.tgz",
@@ -12859,6 +12912,11 @@
       "integrity": "sha512-mT8iDcrh03qDGRRmoA2hmBJnxpllMR+0/0qlzjqZES6NdiWDcZkCNAk4rPFZ9Q85r27unkiNNg8ZOiwZXBHwcA==",
       "dev": true
     },
+    "charenc": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/charenc/-/charenc-0.0.2.tgz",
+      "integrity": "sha512-yrLQ/yVUFXkzg7EDQsPieE/53+0RlaWTs+wBrvW36cyilJ2SaDWfl4Yj7MtLTXleV9uEKefbAGUPv2/iWSooRA=="
+    },
     "chokidar": {
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-3.5.3.tgz",
@@ -13100,6 +13158,11 @@
         "shebang-command": "^2.0.0",
         "which": "^2.0.1"
       }
+    },
+    "crypt": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/crypt/-/crypt-0.0.2.tgz",
+      "integrity": "sha512-mCxBlsHFYh9C+HVpiEacem8FEBnMXgU9gy4zmNC+SXAZNB/1idgp/aulFJ4FgCi7GPEVbfyng092GqL2k2rmow=="
     },
     "cssfilter": {
       "version": "0.0.10",
@@ -14482,6 +14545,11 @@
         "has-tostringtag": "^1.0.0"
       }
     },
+    "is-buffer": {
+      "version": "1.1.6",
+      "resolved": "https://registry.npmjs.org/is-buffer/-/is-buffer-1.1.6.tgz",
+      "integrity": "sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w=="
+    },
     "is-callable": {
       "version": "1.2.7",
       "resolved": "https://registry.npmjs.org/is-callable/-/is-callable-1.2.7.tgz",
@@ -15572,6 +15640,16 @@
       "dev": true,
       "requires": {
         "tmpl": "1.0.5"
+      }
+    },
+    "md5": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/md5/-/md5-2.3.0.tgz",
+      "integrity": "sha512-T1GITYmFaKuO91vxyoQMFETst+O71VUPEU3ze5GNzDm0OWdP8v1ziTaAEPUr/3kLsY3Sftgz242A1SetQiDL7g==",
+      "requires": {
+        "charenc": "0.0.2",
+        "crypt": "0.0.2",
+        "is-buffer": "~1.1.6"
       }
     },
     "media-typer": {

--- a/sample/23-graphql-code-first/package.json
+++ b/sample/23-graphql-code-first/package.json
@@ -25,6 +25,7 @@
     "@nestjs/core": "9.3.12",
     "@nestjs/graphql": "11.0.0",
     "@nestjs/platform-express": "9.3.12",
+    "@nestjs/throttler": "^4.0.0",
     "class-transformer": "0.5.1",
     "class-validator": "0.14.0",
     "graphql": "16.6.0",

--- a/sample/23-graphql-code-first/src/app.module.ts
+++ b/sample/23-graphql-code-first/src/app.module.ts
@@ -1,6 +1,7 @@
 import { ApolloDriver, ApolloDriverConfig } from '@nestjs/apollo';
 import { Module } from '@nestjs/common';
 import { GraphQLModule } from '@nestjs/graphql';
+import { ThrottlerModule } from '@nestjs/throttler';
 import { DirectiveLocation, GraphQLDirective } from 'graphql';
 import { upperDirectiveTransformer } from './common/directives/upper-case.directive';
 import { RecipesModule } from './recipes/recipes.module';
@@ -8,6 +9,10 @@ import { RecipesModule } from './recipes/recipes.module';
 @Module({
   imports: [
     RecipesModule,
+    ThrottlerModule.forRoot({
+      ttl: 60,
+      limit: 10,
+    }),
     GraphQLModule.forRoot<ApolloDriverConfig>({
       driver: ApolloDriver,
       autoSchemaFile: 'schema.gql',

--- a/sample/23-graphql-code-first/src/recipes/recipes.module.ts
+++ b/sample/23-graphql-code-first/src/recipes/recipes.module.ts
@@ -2,8 +2,9 @@ import { Module } from '@nestjs/common';
 import { DateScalar } from '../common/scalars/date.scalar';
 import { RecipesResolver } from './recipes.resolver';
 import { RecipesService } from './recipes.service';
+import {GqlThrottlerGuard} from "./throttler.guard";
 
 @Module({
-  providers: [RecipesResolver, RecipesService, DateScalar],
+  providers: [RecipesResolver, RecipesService, DateScalar, GqlThrottlerGuard],
 })
 export class RecipesModule {}

--- a/sample/23-graphql-code-first/src/recipes/recipes.resolver.ts
+++ b/sample/23-graphql-code-first/src/recipes/recipes.resolver.ts
@@ -1,13 +1,15 @@
-import { NotFoundException } from '@nestjs/common';
+import {NotFoundException, UseGuards} from '@nestjs/common';
 import { Args, Mutation, Query, Resolver, Subscription } from '@nestjs/graphql';
 import { PubSub } from 'graphql-subscriptions';
 import { NewRecipeInput } from './dto/new-recipe.input';
 import { RecipesArgs } from './dto/recipes.args';
 import { Recipe } from './models/recipe.model';
 import { RecipesService } from './recipes.service';
+import {GqlThrottlerGuard} from "./throttler.guard";
 
 const pubSub = new PubSub();
 
+@UseGuards(GqlThrottlerGuard)
 @Resolver(of => Recipe)
 export class RecipesResolver {
   constructor(private readonly recipesService: RecipesService) {}

--- a/sample/23-graphql-code-first/src/recipes/throttler.guard.ts
+++ b/sample/23-graphql-code-first/src/recipes/throttler.guard.ts
@@ -1,0 +1,13 @@
+import {ExecutionContext, Injectable} from "@nestjs/common";
+import {ThrottlerGuard} from "@nestjs/throttler";
+import {GqlExecutionContext} from "@nestjs/graphql";
+
+@Injectable()
+export class GqlThrottlerGuard extends ThrottlerGuard {
+  getRequestResponse(context: ExecutionContext) {
+    const gqlCtx = GqlExecutionContext.create(context);
+    const ctx = gqlCtx.getContext();
+    console.log('custom getRequestResponse is being called')
+    return { req: ctx.req, res: ctx.res }; // ctx.request and ctx.reply for fastify
+  }
+}


### PR DESCRIPTION
Reproduce:
1. run `npm install`
1. run `npm start` in `sample/23-graphql-code-first`
2. visit http://localhost:3000/graphql
3. execute query `{recipes{title}}`
4. see output:
```
[Nest] 95109  - 31/03/2023, 09:21:31   ERROR [ExceptionsHandler] Cannot read properties of undefined (reading 'header')
TypeError: Cannot read properties of undefined (reading 'header')
    at GqlThrottlerGuard.handleRequest (/[...]/sample/23-graphql-code-first/node_modules/@nestjs/throttler/src/throttler.guard.ts:88:9)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
asdf
[Nest] 95109  - 31/03/2023, 09:21:32   ERROR [ExceptionsHandler] Cannot read properties of undefined (reading 'header')
TypeError: Cannot read properties of undefined (reading 'header')
    at GqlThrottlerGuard.handleRequest (/[...]/sample/23-graphql-code-first/node_modules/@nestjs/throttler/src/throttler.guard.ts:88:9)
    at processTicksAndRejections (node:internal/process/task_queues:96:5)
```